### PR TITLE
Make new elixir compiler happy about types

### DIFF
--- a/lesson_03/homework/quadratic_equation_test.exs
+++ b/lesson_03/homework/quadratic_equation_test.exs
@@ -6,17 +6,16 @@ defmodule QuadraticEquationTest do
   import QuadraticEquation
 
   test "solve" do
-    assert solve(1, -2, -3) == {:roots, 3, -1}
-    assert solve(-1, -2, 15) == {:roots, -5, 3}
-    assert solve(1, 12, 36) == {:root, -6}
+    assert solve(1, -2, -3) == {:roots, 3.0, -1.0}
+    assert solve(-1, -2, 15) == {:roots, -5.0, 3.0}
+    assert solve(1, 12, 36) == {:root, -6.0}
     assert solve(5, 3, 7) == :no_roots
   end
 
   test "solve reduced" do
     assert solve(4, 0, -9) == {:roots, 1.5, -1.5}
-    assert solve(1, -7, 0) == {:roots, 7, 0}
-    assert solve(42, 0, 0) == {:root, 0}
+    assert solve(1, -7, 0) == {:roots, 7.0, 0.0}
+    assert solve(42, 0, 0) == {:root, 0.0}
     assert solve(5, 0, 30) == :no_roots
   end
-
 end


### PR DESCRIPTION
Похоже новый elixir 1.18.3 начал выводить типы и сравнивать как они используются.  И ему не нравится, когда в тестах float() сравнивают с integer. Вот так он жалуется на типы без этого фикса:

```
╰─➤  elixir quadratic_equation_test.exs
    warning: comparison between distinct types found:

        left == right

    given types:

        dynamic(:no_roots or {:root, float()} or {:roots, float(), float()}) ==
          {:roots, integer(), integer()}

    where "left" (context ExUnit.Assertions) was given the type:

        # type: dynamic(:no_roots or {:root, float()} or {:roots, float(), float()})
        # from: quadratic_equation_test.exs:9
        left = QuadraticEquation.solve(1, -2, -3)

    where "right" (context ExUnit.Assertions) was given the type:

        # type: {:roots, integer(), integer()}
        # from: quadratic_equation_test.exs:9
        right = {:roots, 3, -1}

    While Elixir can compare across all types, you are comparing across types which are always disjoint, and the result is either always true or always false

    typing violation found at:
    │
  9 │     assert solve(1, -2, -3) == {:roots, 3, -1}
    │                             ~
    │
    └─ quadratic_equation_test.exs:9:29: QuadraticEquationTest."test solve"/1

Running ExUnit with seed: 259090, max_cases: 12

...
Finished in 0.08 seconds (0.08s on load, 0.00s async, 0.00s sync)
```

С фиксом все ок:
```
╰─➤  elixir quadratic_equation_test.exs
Running ExUnit with seed: 777316, max_cases: 12

...
Finished in 0.07 seconds (0.07s on load, 0.00s async, 0.00s sync)
1 doctest, 2 tests, 0 failures
```

PS: Однако красиво эликсир выводит типы теперь. Функция выглядела просто:
```elixir
  def solve(a, b, c) do
    case b ** 2 - 4 * a * c do
      0 -> {:root, -b / (2 * a)}
      d when d < 0 -> :no_roots
      d -> {:roots, (-b + :math.sqrt(d)) / (2 * a), (-b - :math.sqrt(d)) / (2 * a)}
    end
  end
```